### PR TITLE
fix(#573): add error handling to HomeComponent.ngOnInit()

### DIFF
--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HomeComponent } from './home.component';
 import { VideoService } from '../services/video.service';
 import { Video } from '../services/video';
-import { provideRouter } from '@angular/router';
+import { provideRouter, Router } from '@angular/router';
 import { VideoDetailsComponent } from '../video-details/video-details.component';
 
 describe('HomeComponent', () => {
@@ -156,5 +156,16 @@ describe('HomeComponent', () => {
     // Then clear search
     component.filterResults('');
     expect(component.filteredVideos.length).toBe(3);
+  });
+
+  it('should navigate to /500 when getAllVideos fails', async () => {
+    videoService.getAllVideos.mockRejectedValue(new Error('API error'));
+    const router = TestBed.inject(Router);
+    jest.spyOn(router, 'navigate');
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(router.navigate).toHaveBeenCalledWith(['/500']);
   });
 });

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, ChangeDetectorRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
 import { VideoCardComponent } from '../video-card/video-card.component';
 import { Video } from '../services/video';
 import { VideoService } from '../services/video.service';
@@ -35,20 +36,27 @@ export class HomeComponent implements OnInit {
 
   constructor(
     private videoService: VideoService,
+    private router: Router,
     private cdr: ChangeDetectorRef
   ) {}
 
   ngOnInit() {
-    this.videoService.getAllVideos().then((list: Video[]) => {
-      this.videos = list.sort((a, b) => {
-        // Sort by createdAt (newest first)
-        return (
-          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-        );
+    this.videoService
+      .getAllVideos()
+      .then((list: Video[]) => {
+        this.videos = list.sort((a, b) => {
+          // Sort by createdAt (newest first)
+          return (
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+          );
+        });
+        this.filteredVideos = this.videos;
+        this.cdr.markForCheck();
+      })
+      .catch((error) => {
+        console.error('Error loading videos:', error);
+        this.router.navigate(['/500']);
       });
-      this.filteredVideos = this.videos;
-      this.cdr.markForCheck();
-    });
   }
 
   filterResults(text: string) {


### PR DESCRIPTION
.catch() added to the getAllVideos() call — logs the error and navigates to /500 so API failures are surfaced to the user instead of failing silently. Test added to verify navigation on API failure.