### PR TITLE
feat(#580): add loading state to home and footer components

### DIFF
--- a/src/app/footer/footer.component.spec.ts
+++ b/src/app/footer/footer.component.spec.ts
@@ -233,6 +233,33 @@ describe('FooterComponent', () => {
     expect(mockWebLinksService.getWebLinks).toHaveBeenCalled();
   });
 
+  it('should hide footer-left and footer-right while loading', () => {
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement;
+    expect(compiled.querySelector('.footer-left')).toBeFalsy();
+    expect(compiled.querySelector('.footer-right')).toBeFalsy();
+    expect(compiled.querySelector('.footer-center')).toBeTruthy();
+  });
+
+  it('should show footer-left and footer-right after links are loaded', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement;
+    expect(compiled.querySelector('.footer-left')).toBeTruthy();
+    expect(compiled.querySelector('.footer-right')).toBeTruthy();
+  });
+
+  it('should show footer-left and footer-right after failed fetch', async () => {
+    mockWebLinksService.getWebLinks.mockRejectedValue(new Error('API error'));
+    fixture = TestBed.createComponent(FooterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(component.isLoading).toBe(false);
+  });
+
   it('should log an error when getWebLinks fails', async () => {
     const consoleSpy = jest
       .spyOn(console, 'error')

--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -9,7 +9,7 @@ import { WebLinksService } from '../services/web-links.service';
   template: `
     <footer class="footer">
       <div class="footer-content">
-        <div class="footer-left">
+        <div class="footer-left" *ngIf="!isLoading">
           <!-- <a href="/privacy">Privacy</a>
           <span class="separator">|</span>
           <a href="/imprint">Imprint</a>
@@ -28,7 +28,7 @@ import { WebLinksService } from '../services/web-links.service';
         <div class="footer-center">
           <p>&copy; {{ copyrightYears }} Andy Grails</p>
         </div>
-        <div class="footer-right">
+        <div class="footer-right" *ngIf="!isLoading">
           <a
             *ngIf="youtubeLink"
             [href]="youtubeLink.url"
@@ -63,6 +63,7 @@ import { WebLinksService } from '../services/web-links.service';
   styleUrls: ['./footer.component.scss'],
 })
 export class FooterComponent implements OnInit {
+  isLoading = true;
   webLinks: WebLink[] = [];
   youtubeLink?: WebLink;
   instagramLink?: WebLink;
@@ -98,9 +99,11 @@ export class FooterComponent implements OnInit {
         this.issueTrackerLink = links.find(
           (link) => link.type === 'ISSUE_TRACKER'
         );
+        this.isLoading = false;
         this.cdr.markForCheck();
       })
       .catch((error) => {
+        this.isLoading = false;
         console.error('Error loading footer links:', error);
       });
   }

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -37,5 +37,32 @@
   @media (max-width: 499px) {
     .results {
         grid-template-columns: 1fr;
-    }    
+    }
   }
+
+.loading-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 0;
+}
+
+.spinner {
+  width: 48px;
+  height: 48px;
+  border: 4px solid var(--background-secondary);
+  border-top-color: var(--primary-color);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  margin-bottom: 16px;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.loading-text {
+  color: var(--primary-color);
+  font-size: 0.9rem;
+}

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -168,4 +168,29 @@ describe('HomeComponent', () => {
 
     expect(router.navigate).toHaveBeenCalledWith(['/500']);
   });
+
+  it('should show loading spinner while fetching videos', () => {
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement;
+    expect(compiled.querySelector('.loading-container')).toBeTruthy();
+    expect(compiled.querySelector('.spinner')).toBeTruthy();
+    expect(compiled.querySelector('.loading-text').textContent.trim()).toBe('Loading videos...');
+  });
+
+  it('should hide loading spinner and show content after videos are loaded', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement;
+    expect(compiled.querySelector('.loading-container')).toBeFalsy();
+    expect(compiled.querySelector('.results')).toBeTruthy();
+  });
+
+  it('should hide loading spinner after failed fetch', async () => {
+    videoService.getAllVideos.mockRejectedValue(new Error('API error'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(component.isLoading).toBe(false);
+  });
 });

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -10,7 +10,11 @@ import { VideoService } from '../services/video.service';
   selector: 'app-home',
   imports: [CommonModule, VideoCardComponent, FormsModule],
   template: `
-    <section>
+    <div *ngIf="isLoading" class="loading-container">
+      <div class="spinner"></div>
+      <p class="loading-text">Loading videos...</p>
+    </div>
+    <section *ngIf="!isLoading">
       <form (submit)="filterResults(filter.value); $event.preventDefault()">
         <input
           type="text"
@@ -20,7 +24,7 @@ import { VideoService } from '../services/video.service';
         <button class="primary" type="submit">Search</button>
       </form>
     </section>
-    <section class="results">
+    <section *ngIf="!isLoading" class="results">
       <app-video-card
         *ngFor="let video of filteredVideos"
         [video]="video"
@@ -30,6 +34,7 @@ import { VideoService } from '../services/video.service';
   styleUrls: ['./home.component.scss'],
 })
 export class HomeComponent implements OnInit {
+  isLoading = true;
   videos: Video[] = [];
 
   filteredVideos: Video[] = [];
@@ -51,9 +56,11 @@ export class HomeComponent implements OnInit {
           );
         });
         this.filteredVideos = this.videos;
+        this.isLoading = false;
         this.cdr.markForCheck();
       })
       .catch((error) => {
+        this.isLoading = false;
         console.error('Error loading videos:', error);
         this.router.navigate(['/500']);
       });


### PR DESCRIPTION
Show a CSS spinner with "Loading videos..." text in the home component while videos are being fetched, and hide footer link sections until web links are loaded.