### PR TITLE
build(#608): make Dependabot use Conventional Commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "build" # Conventional Commits type, e.g. build(deps): bump ...
+      include: "scope" # Adds (deps) / (deps-dev) scope


### PR DESCRIPTION
Pin the commit convention explicitly instead of relying on Dependabot's auto-detection of the repository's commit history, so bumps always render as build(deps): / build(deps-dev):.